### PR TITLE
Use updated upload_pypi action

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,11 +56,6 @@ jobs:
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: neuroinformatics-unit/actions/upload_pypi@v2
       with:
-        name: artifact
-        path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.5.0
-      with:
-        user: __token__
-        password: ${{ secrets.TWINE_API_KEY }}
+        secret-pypi-key: ${{ secrets.TWINE_API_KEY }}


### PR DESCRIPTION
## Context

We recently, bumped the versions of many actions in the [NIU actions](https://github.com/neuroinformatics-unit/actions) repository, with the help of `dependabot`. Among many other changes, `actions/upload-artifact` was bumped to `v4`.

This change is incompatible with older major versions of `actions/download-artifact`  which we use within this repo's GitHub workflow, specifically in the step that uploads the package to PyPI.

## Solution

The easy fix would be to also bump `actions/download-artifact` to `v4` within the workflow, but we want to avoid having to do that for any future actions updates.

Therefore, this PR modifies the PyPI upload logic of the workflow, so that it leverages our reusable [upload_pypi action](https://github.com/neuroinformatics-unit/actions/tree/main/upload_pypi), which has also been updated to fulfill that purpose.

In this way, we should avoid having to modify the individual repo workflows. In the future, the relevant bumps will have to be implemented only upstream, in [NIU actions](https://github.com/neuroinformatics-unit/actions).

## How has this been tested
We made a new PyPI release of [brainglobe-template-builder](https://github.com/brainglobe/brainglobe-template-builder) using this updated workflow, and it went down smoothly. 