### PR TITLE
update pypi action to latest

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -59,4 +59,3 @@ jobs:
     - uses: neuroinformatics-unit/actions/upload_pypi@v2
       with:
         secret-pypi-key: ${{ secrets.TWINE_API_KEY }}
-

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,11 +56,7 @@ jobs:
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: neuroinformatics-unit/actions/upload_pypi@v2
       with:
-        name: artifact
-        path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.5.0
-      with:
-        user: __token__
-        password: ${{ secrets.TWINE_API_KEY }}
+        secret-pypi-key: ${{ secrets.TWINE_API_KEY }}
+


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Workflow was using an old download-artifact action, which was [flagged by dependabot](https://github.com/neuroinformatics-unit/rsp-vision/security/dependabot?q=is%3Aopen+manifest%3A.github%2Fworkflows%2Ftest_and_deploy.yml+package%3Aactions%2Fdownload-artifact)

**What does this PR do?**

Updates to latest pypi-upload action (which doesn't explicitly use the download-artifact action anymore)